### PR TITLE
run every kind of Jenkins job, preferring the queue-item API

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# This hook was set by cargo-husky v1.5.0: https://github.com/rhysd/cargo-husky#readme
 # Pre-commit hook: format staged files via treefmt, then re-stage them.
 # treefmt reads treefmt.toml and dispatches each file to the correct
 # language-specific formatter automatically.

--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -80,7 +80,7 @@ echo "API token generated for ci-token"
 # finish before the real tests run.  The API token bypasses CSRF, so these POSTs
 # need no crumb.
 echo "Hydrating jobs so their parameters register..."
-HYDRATE_JOBS="sleep-job fail-job unstable-job build-with-parameters-test"
+HYDRATE_JOBS="sleep-job fail-job unstable-job build-with-parameters-test no-parameters-test extended-choice-test"
 for job in $HYDRATE_JOBS; do
   curl --silent --fail --request POST --user "admin:$API_TOKEN" \
     "http://localhost:11990/job/$job/build" >/dev/null || true

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -21,7 +21,19 @@ automatically.
 
 ** Upcoming
 *** Added
+1. Each server entry accepts a ~build_with_parameters_additional_types~ list of
+   Jenkins parameter class names.  jj already runs jobs using the core parameter
+   types through Jenkins' race-free queue API and falls back to the build form
+   for any other type; add a plugin's parameter class here once you have
+   confirmed Jenkins carries its value via ~buildWithParameters~, to keep that
+   plugin's runs on the queue path.  No action is needed unless you use such a
+   plugin.
 *** Fixes
+1. jj can now run every kind of Jenkins job: one that declares no parameters,
+   one run with its defaults, and one given values — including rich parameter
+   types such as an extended-choice parameter whose value the previous approach
+   silently dropped.  Previously a parameterless job could not run at all and
+   some parameterized runs lost their values.  No action is needed.
 *** Breaking
 ** v0.2.0
 *** Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,9 +267,9 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -628,7 +628,6 @@ dependencies = [
  "rust-template-foundation",
  "serde",
  "serde_json",
- "serde_url_params",
  "serial_test",
  "tap",
  "tempfile",
@@ -1006,7 +1005,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1410,16 +1409,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_url_params"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c43307d0640738af32fe8d01e47119bc0fc8a686be470a44a586caff76dfb34"
-dependencies = [
- "serde",
- "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ either = "1"
 futures = "0.3"
 bytes = "1"
 url = "2"
-serde_url_params = "0.2"
 jj-lib = { path = "crates/lib" }
 assert_cmd = "2"
 predicates = "3"

--- a/README.org
+++ b/README.org
@@ -71,6 +71,23 @@ Simply use =--param foo=bar= or =-P foo=bar= (add more =--params= / =-P= uses
 for additional parameters) to provide parameters to the build.  Otherwise its
 defaults will be assumed for all missing parameters.
 
+When every parameter a run sets is a core Jenkins type, =jj= submits it through
+Jenkins' =buildWithParameters= API and watches the exact build with no race.  A
+run that sets a parameter of a plugin-provided type =jj= does not recognise
+instead goes through the build form, which carries any value but leaves a small
+race if the /same/ job is triggered concurrently while =jj= is starting it.  If
+a plugin's parameter works with =buildWithParameters= on your Jenkins and you
+want its runs kept on the race-free path, list that parameter's class name under
+the server with =build_with_parameters_additional_types=:
+
+#+begin_example toml
+[foo]
+host_url = "http://jenkins.foo:8080"
+username = "jeeves"
+token_eval = "pass jenkins-foo-api-token"
+build_with_parameters_additional_types = ["org.example.MyParameterDefinition"]
+#+end_example
+
 ** jobs with approval gates
 
 Coming soon!

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -28,13 +28,13 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
-# Compile-time-validated queue-message regexes; see the workspace comment.
+# Compile-time-validated regex for parsing Jenkins' quiet-period `why` messages.
 lazy-regex = { workspace = true }
+# Either models the queue poll's "wait this long" vs "here is the build" split.
 either = { workspace = true }
 futures = { workspace = true }
 bytes = { workspace = true }
 url = { workspace = true }
-serde_url_params = { workspace = true }
 # Enables method chaining and reduces superfluous local variables that only
 # exist to name intermediate results.  Prefer .tap() over temporary variables
 # when it improves readability.

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -67,6 +67,8 @@ impl Config {
               host_url: server.host_url,
               token: token_eval(&server.token_eval)?,
               username,
+              build_with_parameters_additional_types: server
+                .build_with_parameters_additional_types,
             },
           ))
         })
@@ -92,6 +94,10 @@ pub struct ConfigServer {
   pub host_url: String,
   pub username: String,
   pub token: String,
+  /// Extra Jenkins parameter `_class` names this server may submit through
+  /// `buildWithParameters`; see
+  /// [`ConfigServerFileRaw::build_with_parameters_additional_types`].
+  pub build_with_parameters_additional_types: Vec<String>,
 }
 
 /// Config-file shape for jj's server registry: `default_server` alongside a
@@ -111,6 +117,14 @@ pub struct ConfigServerFileRaw {
   // token, wrap it in single quotes: "'my-token'".
   pub token_eval: String,
   pub username: Option<String>,
+  /// Jenkins parameter `_class` names — in addition to jj's built-in core
+  /// types — that jj may submit through `buildWithParameters`, its race-free
+  /// queue path.  A run that sets a parameter of any other type falls back to
+  /// the `/build` form (which carries every type but cannot hand back a queue
+  /// handle).  List a plugin's parameter type here once you have confirmed
+  /// buildWithParameters carries its value on your Jenkins.
+  #[serde(default)]
+  pub build_with_parameters_additional_types: Vec<String>,
 }
 
 /// jj-specific configuration failures, surfaced through the derive's

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -4,12 +4,10 @@ use thiserror::Error;
 pub enum AppError {
   #[error("Server '{0}' not found in configuration")]
   CliConfigServerMissing(String),
-  #[error("Jenkins build not found in response headers")]
-  JenkinsBuildNotFound,
   #[error("Failed to parse build text size header")]
   JenkinsBuildParseTextSize,
   #[error("Failed to serialize build parameters: {0}")]
-  JenkinsBuildParamSerialize(serde_url_params::Error),
+  JenkinsBuildParamSerialize(serde_json::Error),
   #[error("Failed to stream build log: {0}")]
   JenkinsBuildStream(reqwest_middleware::Error),
   #[error("Failed to read build response body: {0}")]
@@ -18,14 +16,22 @@ pub enum AppError {
   JenkinsBuildOutput(std::io::Error),
   #[error("Failed to deserialize Jenkins response: {0}")]
   JenkinsDeserialize(serde_json::Error),
+  #[error("Failed to request the job's parameter definitions: {0}")]
+  JenkinsParameterDefinitions(reqwest_middleware::Error),
   #[error("Failed to enqueue Jenkins build: {0}")]
   JenkinsEnqueue(reqwest_middleware::Error),
-  #[error("Failed to deserialize Jenkins queue response: {0}")]
-  JenkinsEnqueueDeserialize(String),
-  #[error("Failed to parse queue wait duration: {0}")]
-  JenkinsEnqueueSecondsParse(std::num::ParseIntError),
-  #[error("Unrecognized queue wait reason: {0}")]
-  JenkinsEnqueueWait(String),
+  #[error("Jenkins rejected the build enqueue with status {0}")]
+  JenkinsEnqueueRejected(reqwest::StatusCode),
+  #[error("Jenkins returned no queue-item Location for the enqueued build")]
+  JenkinsBuildNotFound,
+  #[error("Failed to poll the queue item for the started build: {0}")]
+  JenkinsQueueItemAwait(reqwest_middleware::Error),
+  #[error("Failed to request the job's next build number: {0}")]
+  JenkinsNextBuildNumber(reqwest_middleware::Error),
+  #[error("Failed to poll for the enqueued build to start: {0}")]
+  JenkinsBuildAwait(reqwest_middleware::Error),
+  #[error("Unexpected status {0} while waiting for the build to start")]
+  JenkinsBuildAwaitStatus(reqwest::StatusCode),
   #[error("Failed to parse response header value: {0}")]
   JenkinsHeader(reqwest::header::ToStrError),
   #[error("Failed to request Jenkins job builds: {0}")]

--- a/crates/cli/src/follow.rs
+++ b/crates/cli/src/follow.rs
@@ -3,10 +3,12 @@ use std::time::Duration;
 
 use hash_color_lib::{ColorizerOptions, HashColorizer};
 use jj_lib::build::BuildExitCode;
+use reqwest_middleware::ClientWithMiddleware;
 use tokio::{signal, task::JoinSet, time};
 use tracing::{error, info};
 
 use crate::cli::CliJobFollowValid;
+use crate::config::ConfigServer;
 use crate::error::AppError;
 use crate::jenkins;
 
@@ -14,6 +16,36 @@ const POLL_INTERVAL: Duration = Duration::from_secs(5);
 
 fn build_colorizer() -> HashColorizer {
   HashColorizer::new(ColorizerOptions::default())
+}
+
+// Spawns a task that streams one build's log to completion, logging its start,
+// completion, or failure.  The build_log_stream await runs inside the spawned
+// task, so `follow`'s loop fans these out concurrently rather than sequencing
+// them.
+fn spawn_build_stream(
+  tasks: &mut JoinSet<()>,
+  client: ClientWithMiddleware,
+  server: ConfigServer,
+  build_number: u64,
+  build_url: String,
+) {
+  tasks.spawn(async move {
+    let colorizer = build_colorizer();
+    info!(build_number, "Streaming build log");
+    match jenkins::build_log_stream(
+      &client,
+      &server,
+      build_url,
+      0,
+      build_number,
+      &colorizer,
+    )
+    .await
+    {
+      Ok(()) => info!(build_number, "Build stream complete"),
+      Err(e) => error!(build_number, error = %e, "Build stream error"),
+    }
+  });
 }
 
 // Adopts the highest-numbered currently-running build, or waits for the next
@@ -43,6 +75,7 @@ pub async fn follow_once(
     info
   } else {
     loop {
+      // await-in-loop: poll for the next build to start; sequential by nature.
       time::sleep(POLL_INTERVAL).await;
       let new_builds = jenkins::jenkins_job_builds(
         &config.client,
@@ -92,6 +125,9 @@ pub async fn follow(config: &CliJobFollowValid) -> Result<(), AppError> {
   let mut interval = time::interval(POLL_INTERVAL);
 
   loop {
+    // await-in-loop: an event loop — select! multiplexes Ctrl-C, the poll tick,
+    // and task completion.  The streaming awaits run in the tasks spawned below,
+    // not here.
     tokio::select! {
       _ = signal::ctrl_c() => break,
       _ = interval.tick() => {
@@ -104,29 +140,13 @@ pub async fn follow(config: &CliJobFollowValid) -> Result<(), AppError> {
             for build in builds.builds {
               if build.building && !seen.contains(&build.number) {
                 seen.insert(build.number);
-                let client_clone = config.client.clone();
-                let server_clone = config.server.clone();
-                let build_number = build.number;
-                let build_url = build.url.clone();
-                tasks.spawn(async move {
-                  let col = build_colorizer();
-                  info!(build_number, "Streaming build log");
-                  match jenkins::build_log_stream(
-                    &client_clone,
-                    &server_clone,
-                    build_url,
-                    0,
-                    build_number,
-                    &col,
-                  )
-                  .await
-                  {
-                    Ok(()) => info!(build_number, "Build stream complete"),
-                    Err(e) => {
-                      error!(build_number, error = %e, "Build stream error")
-                    }
-                  }
-                });
+                spawn_build_stream(
+                  &mut tasks,
+                  config.client.clone(),
+                  config.server.clone(),
+                  build.number,
+                  build.url,
+                );
               }
             }
           }

--- a/crates/cli/src/jenkins.rs
+++ b/crates/cli/src/jenkins.rs
@@ -13,7 +13,6 @@
 // for strict contracts, documented edge cases, etc.  In absence of this hard
 // documentation, we will assume a defensive posture with Jenkins.
 use either::{Either, Left, Right};
-use futures::FutureExt;
 use futures::StreamExt;
 use hash_color_lib::HashColorizer;
 use jj_lib::build::BuildStatus;
@@ -37,65 +36,6 @@ pub struct BufferedResponse {
   pub headers: reqwest::header::HeaderMap,
   pub status: reqwest::StatusCode,
   pub text: String,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct JenkinsQueueItem {
-  #[serde(alias = "_class")]
-  pub class: String,
-  pub actions: Vec<JenkinsQueueItemAction>,
-  pub blocked: bool,
-  pub buildable: bool,
-  pub executable: Option<JenkinsQueueItemExecutable>,
-  pub id: u32,
-  pub in_queue_since: u64,
-  pub params: String,
-  pub task: JenkinsQueueItemTask,
-  pub url: String,
-  pub why: Option<String>,
-  pub timestamp: Option<u64>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct JenkinsQueueItemAction {
-  #[serde(alias = "_class")]
-  pub class: String,
-  pub causes: Option<Vec<JenkinsQueueItemActionCause>>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct JenkinsQueueItemExecutable {
-  #[serde(alias = "_class")]
-  pub class: String,
-  pub number: u64,
-  pub url: String,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct JenkinsQueueItemActionCause {
-  // This value is rather important.  One example is
-  // "hudson.model.Cause$UserIdCause" to indicate a user started the build
-  // manually.
-  #[serde(alias = "_class")]
-  pub class: String,
-  pub short_description: String,
-  pub user_id: String,
-  pub user_name: String,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct JenkinsQueueItemTask {
-  #[serde(alias = "_class")]
-  pub class: String,
-  pub name: String,
-  pub url: String,
-  // Color is indicative of the build's status.
-  pub color: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -182,36 +122,185 @@ async fn to_buffered_response(
   })
 }
 
-pub fn params_to_query_params(
+// Serializes the run's parameters into the `json` form payload the Jenkins web
+// UI submits: an array of {name, value} objects.  This is the only submission
+// form every parameter type understands; buildWithParameters silently drops
+// values for richer types such as ExtendedChoiceParameter (JENKINS-57125), so
+// jj posts this payload through /build instead.
+fn params_to_json_payload(
   params: &HashMap<String, String>,
 ) -> Result<String, AppError> {
-  serde_url_params::to_string(&params).map_err(JenkinsBuildParamSerialize)
+  #[derive(Serialize)]
+  struct BuildParam<'a> {
+    name: &'a str,
+    value: &'a str,
+  }
+  #[derive(Serialize)]
+  struct BuildParams<'a> {
+    parameter: Vec<BuildParam<'a>>,
+  }
+  serde_json::to_string(&BuildParams {
+    parameter: params
+      .iter()
+      .map(|(name, value)| BuildParam { name, value })
+      .collect(),
+  })
+  .map_err(JenkinsBuildParamSerialize)
 }
 
-// Returns the link to the queue item.
-pub async fn build_enqueue(
+// Jenkins offers no single enqueue endpoint that both carries every parameter
+// type and hands back a queue-item handle, so jj picks one per run:
+//
+//   - /build for a parameterless job and /buildWithParameters for a
+//     parameterized one are the documented API and return a queue-item Location
+//     jj can watch precisely (race-free).
+//   - The web UI's /build `json` form is the only form that carries richer
+//     types whose values buildWithParameters silently drops (JENKINS-57125,
+//     e.g. ExtendedChoiceParameter), but it returns the job URL rather than a
+//     queue item (JENKINS-30317, resolved "Not A Defect"), so the build is
+//     watched by number, accepting a small enqueue race for that case.
+//
+// A run takes the queue path only when every parameter it sets is a type
+// buildWithParameters is known to carry (the built-in core types plus any the
+// server config adds); any other run uses the form.  Encoding the known-good
+// types — rather than the ever-growing set of plugin types buildWithParameters
+// drops — means an unrecognized type merely degrades to the race, never
+// silently drops a value.
+
+#[derive(Deserialize)]
+struct JobConfig {
+  #[serde(default)]
+  property: Vec<JobProperty>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct JobProperty {
+  parameter_definitions: Option<Vec<ParameterDefinition>>,
+}
+
+#[derive(Deserialize)]
+struct ParameterDefinition {
+  name: String,
+  #[serde(alias = "_class")]
+  class: String,
+}
+
+#[derive(Deserialize)]
+struct JenkinsQueueItem {
+  executable: Option<JenkinsQueueItemExecutable>,
+  why: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct JenkinsQueueItemExecutable {
+  number: u64,
+  url: String,
+}
+
+// Jenkins core parameter types buildWithParameters is known to carry.  A run
+// that sets only these (plus any the server config adds) can take the race-free
+// queue path.  This is deliberately a known-good list: an unrecognized type
+// degrades to the /build form (the race), never to a silently dropped value.
+const BUILD_WITH_PARAMETERS_CORE_TYPES: &[&str] = &[
+  "hudson.model.StringParameterDefinition",
+  "hudson.model.BooleanParameterDefinition",
+  "hudson.model.ChoiceParameterDefinition",
+  "hudson.model.TextParameterDefinition",
+  "hudson.model.PasswordParameterDefinition",
+];
+
+fn build_with_parameters_safe(class: &str, extra: &[String]) -> bool {
+  BUILD_WITH_PARAMETERS_CORE_TYPES.contains(&class)
+    || extra.iter().any(|t| t == class)
+}
+
+async fn job_parameter_definitions(
+  client: &ClientWithMiddleware,
+  server: &ConfigServer,
+  job: &str,
+) -> Result<Vec<ParameterDefinition>, error::AppError> {
+  let response = jenkins_request(
+    client,
+    server,
+    reqwest::Method::GET,
+    format!("{}/job/{}/api/json", server.host_url, job),
+  )
+  .await
+  .map_err(error::AppError::JenkinsParameterDefinitions)?;
+  let text = response
+    .text()
+    .await
+    .map_err(|e| error::AppError::JenkinsParameterDefinitions(e.into()))?;
+  Ok(
+    serde_json::from_str::<JobConfig>(&text)
+      .map_err(error::AppError::JenkinsDeserialize)?
+      .property
+      .into_iter()
+      .filter_map(|p| p.parameter_definitions)
+      .flatten()
+      .collect(),
+  )
+}
+
+// Enqueues a run and returns its (build URL, build number).  See the comment
+// above for how the endpoint is chosen from the job's parameter types.
+pub async fn build_start(
   client: &ClientWithMiddleware,
   server: &ConfigServer,
   job: &str,
   params: &HashMap<String, String>,
+) -> Result<(String, u64), error::AppError> {
+  let definitions = job_parameter_definitions(client, server, job).await?;
+  if definitions.is_empty() {
+    // Parameterless: bare /build returns a queue item to watch.
+    let url = format!("{}/job/{}/build", server.host_url, job);
+    let queue_url = build_enqueue_to_queue(client, server, url, params).await?;
+    return build_queue_item_poll(client, server, queue_url).await;
+  }
+  // Parameterized: buildWithParameters keeps the race-free queue handle, but
+  // only if every value the run sets is a type it is known to carry.
+  let queue_safe = params.keys().all(|name| {
+    definitions.iter().any(|d| {
+      &d.name == name
+        && build_with_parameters_safe(
+          &d.class,
+          &server.build_with_parameters_additional_types,
+        )
+    })
+  });
+  if queue_safe {
+    let url = format!("{}/job/{}/buildWithParameters", server.host_url, job);
+    let queue_url = build_enqueue_to_queue(client, server, url, params).await?;
+    build_queue_item_poll(client, server, queue_url).await
+  } else {
+    // The form path yields no queue handle, so record the number the next build
+    // will take, enqueue, then watch that build.
+    let build_number = job_next_build_number(client, server, job).await?;
+    build_enqueue_form(client, server, job, params).await?;
+    let build_url =
+      build_await_start(client, server, job, build_number).await?;
+    Ok((build_url, build_number))
+  }
+}
+
+// Enqueues through an endpoint that returns the queue-item Location (bare
+// /build, or /buildWithParameters with the params as query) and returns it.
+async fn build_enqueue_to_queue(
+  client: &ClientWithMiddleware,
+  server: &ConfigServer,
+  url: String,
+  params: &HashMap<String, String>,
 ) -> Result<String, error::AppError> {
-  let url = format!(
-    "{}/job/{}/buildWithParameters?{}",
-    server.host_url,
-    job,
-    params_to_query_params(params)?,
-  );
   debug!("Enqueueing at '{}'", url);
   trace!("Using token {}", server.token);
-  let response = jenkins_request(
-    client,
-    server,
-    reqwest::Method::POST,
-    // I reckon this can't be borrowed because it's going into a Future.
-    url.clone(),
-  )
-  .await
-  .map_err(error::AppError::JenkinsEnqueue)?;
+  let response = client
+    .request(reqwest::Method::POST, url)
+    .basic_auth(&server.username, Some(&server.token))
+    .query(params)
+    .send()
+    .await
+    .map_err(error::AppError::JenkinsEnqueue)?;
   let buffered_response = to_buffered_response(response).await?;
   debug!(
     "result? {}\n{}\n{}",
@@ -219,145 +308,228 @@ pub async fn build_enqueue(
     headers_to_string(buffered_response.headers.clone())?,
     buffered_response.text,
   );
-  // TODO: Return a URL and make sure this is a URL.
-  // Unwrap it here so we can debug the output regardless of outcome.
-  let location = buffered_response
+  if !buffered_response.status.is_success() {
+    return Err(error::AppError::JenkinsEnqueueRejected(
+      buffered_response.status,
+    ));
+  }
+  buffered_response
     .headers
     .get(reqwest::header::LOCATION)
     .ok_or(error::AppError::JenkinsBuildNotFound)?
     .to_str()
-    .map_err(error::AppError::JenkinsHeader)?
-    .to_string();
-  Ok(location)
+    .map_err(error::AppError::JenkinsHeader)
+    .map(str::to_string)
 }
 
+// Enqueues through the web UI's /build `json` form, which carries every
+// parameter type but returns only the job URL (no queue handle).
+async fn build_enqueue_form(
+  client: &ClientWithMiddleware,
+  server: &ConfigServer,
+  job: &str,
+  params: &HashMap<String, String>,
+) -> Result<(), error::AppError> {
+  let url = format!("{}/job/{}/build", server.host_url, job);
+  debug!("Enqueueing (form) at '{}'", url);
+  trace!("Using token {}", server.token);
+  let response = client
+    .request(reqwest::Method::POST, url)
+    .basic_auth(&server.username, Some(&server.token))
+    .form(&[("json", params_to_json_payload(params)?)])
+    .send()
+    .await
+    .map_err(error::AppError::JenkinsEnqueue)?;
+  let buffered_response = to_buffered_response(response).await?;
+  debug!(
+    "result? {}\n{}\n{}",
+    buffered_response.status,
+    headers_to_string(buffered_response.headers.clone())?,
+    buffered_response.text,
+  );
+  if buffered_response.status.is_success() {
+    Ok(())
+  } else {
+    Err(error::AppError::JenkinsEnqueueRejected(buffered_response.status))
+  }
+}
+
+// When jj can read Jenkins' reported quiet-period delay it waits exactly that
+// long before re-checking — the server's own floor; when it cannot (an
+// unrecognised reason such as "Waiting for next available executor") it falls
+// back to this interval and keeps polling.
+const ASSUMED_QUEUE_DELAY: std::time::Duration =
+  std::time::Duration::from_millis(500);
+
+// Parses the delay Jenkins suggests before re-checking a still-queued item from
+// its `why` message.  The reported forms, each a witnessed variation, are:
+//
+//   - "In the quiet period. Expires in 3 sec"
+//   - "In the quiet period. Expires in 3 secs"
+//   - "In the quiet period. Expires in 3.15 sec"
+//   - "In the quiet period. Expires in 3.15 secs"
+//   - "In the quiet period. Expires in 234 ms"
+//   - "In the quiet period. Expires in 1.234 ms"
+//   - "Finished waiting"
+//
+// "Finished waiting" is a small lie — the build URL is not quite ready — so we
+// wait a beat.  Any other message returns None, and the caller polls at
+// ASSUMED_QUEUE_DELAY rather than giving up on a reason it has not seen before.
+fn parse_why(why: &str) -> Option<std::time::Duration> {
+  if why == "Finished waiting" {
+    return Some(std::time::Duration::from_secs(1));
+  }
+  let captures = lazy_regex::regex!(
+    r"^In the quiet period\. Expires in ([0-9]+)(?:\.([0-9]+))? (secs?|ms)$"
+  )
+  .captures(why)?;
+  let whole: u64 = captures.get(1)?.as_str().parse().ok()?;
+  let millis = if captures.get(3)?.as_str() == "ms" {
+    // A fractional millisecond is below our polling resolution, so ignore it.
+    whole
+  } else {
+    // Seconds, with the fractional part read to millisecond resolution: "15"
+    // means 0.15 s (150 ms), "5" means 0.5 s (500 ms).
+    let fraction_ms: String = captures
+      .get(2)
+      .map_or("", |m| m.as_str())
+      .chars()
+      .chain("000".chars())
+      .take(3)
+      .collect();
+    whole * 1000 + fraction_ms.parse::<u64>().unwrap_or(0)
+  };
+  Some(std::time::Duration::from_millis(millis))
+}
+
+// The delay to wait before re-checking a still-queued item: what Jenkins
+// reported, or the assumed interval when its reason is unrecognised.
+fn queue_delay(item: &JenkinsQueueItem) -> std::time::Duration {
+  item.why.as_deref().and_then(parse_why).unwrap_or_else(|| {
+    warn!(
+      "Unrecognised queue reason {:?}; polling at the assumed interval.",
+      item.why,
+    );
+    ASSUMED_QUEUE_DELAY
+  })
+}
+
+// Given a polled queue item, returns either the delay to wait before re-checking
+// (still queued) or the started build's (URL, number).
 fn parse_item(
   item: &JenkinsQueueItem,
-) -> Result<Either<u64, (String, u64)>, error::AppError> {
-  if let Some(ex) = &item.executable {
-    Ok(Right((ex.url.clone(), ex.number)))
-  } else {
-    let why = item.why.as_ref().ok_or_else(|| {
-      error::AppError::JenkinsEnqueueDeserialize(format!(
-        "Both executable and why fields missing data: {:?}",
-        item,
-      ))
-    })?;
-    Ok(Left(parse_why(why)?))
-  }
+) -> Either<std::time::Duration, (String, u64)> {
+  item.executable.as_ref().map_or_else(
+    || Left(queue_delay(item)),
+    |executable| Right((executable.url.clone(), executable.number)),
+  )
 }
 
-fn parse_why(why: &String) -> Result<u64, error::AppError> {
-  // lazy_regex::regex! validates the pattern at compile time and caches a
-  // &'static Regex, so a bad pattern is a compile error rather than a runtime
-  // Regex::new to unwrap.
-  //
-  // Examples witnessed:
-  // Expires in 1.234 ms
-  // Expires in 3 sec
-  // Expires in 3.15 sec
-  // Expires in 3 secs
-  let queue_delay_regex = lazy_regex::regex!(
-    r"^In the quiet period\. Expires in (?:(?P<secs1>[0-9]+) secs?)|(?:(?P<secs2>[0-9]+)\.(?P<millis1>[0-9]+) secs?)|(?:(?P<millis2>[0-9]+) ms)$"
-  );
-  let queue_finished_waiting_regex = lazy_regex::regex!(r"^Finished waiting$");
-  let option = queue_delay_regex
-    .captures(why)
-    .and_then(|c| {
-      Some((
-        // Sometimes we get "Expires in x.y secs" and others "Expires in x ms".
-        // Instead of chained conditional logic, assume 0 seconds for the
-        // latter form.
-        c.name("secs1")
-          .or(c.name("secs2"))
-          .map(|x| x.as_str())
-          .or(Some("0"))?,
-        c.name("millis1").or(c.name("millis2"))?.as_str(),
-      ))
-    })
-    .or_else(|| {
-      if queue_finished_waiting_regex.is_match(why) {
-        // Just wait for a second.  "Finished waiting" is actually a lie; we
-        // need to wait a little more before the build URL becomes available.
-        Some(("1", "0"))
-      } else {
-        None
-      }
-    });
-  match option {
-    Some((seconds_string, millis_string)) => {
-      let seconds = seconds_string
-        .parse::<u64>()
-        .map_err(error::AppError::JenkinsEnqueueSecondsParse)?
-        * 1000;
-      let millis = millis_string
-        .parse::<u64>()
-        .map_err(error::AppError::JenkinsEnqueueSecondsParse)?;
-      Ok(seconds + millis)
-    }
-    None => Err(error::AppError::JenkinsEnqueueWait(format!(
-      "Queue item's why of '{}' does not match regular expression /{}/.",
-      why,
-      queue_delay_regex.as_str(),
-    ))),
-  }
-}
-
-// Uses waiting period to poll for the queue item's state.  Returns the build
-// URL and build number once the item leaves the queue.
-// Boxed because the poll future is recursive: it re-enters
-// build_queue_item_poll after sleeping, which a bare `impl Future` cannot
-// express.
-type QueueItemPollFuture<'a> = std::pin::Pin<
-  Box<
-    dyn std::future::Future<Output = Result<(String, u64), error::AppError>>
-      + Send
-      + 'a,
-  >,
->;
-
-pub fn build_queue_item_poll<'a>(
-  client: &'a ClientWithMiddleware,
-  server: &'a ConfigServer,
-  url: String,
-) -> QueueItemPollFuture<'a> {
-  async move {
-    let item = build_queue_item_get(client, server, url.clone()).await?;
-    match parse_item(&item)? {
-      Left(expires_millis) => {
-        std::thread::sleep(std::time::Duration::from_millis(expires_millis));
-        build_queue_item_poll(client, server, url).await
-      }
-      Right((build_url, build_number)) => Ok((build_url, build_number)),
-    }
-  }
-  .boxed()
-}
-
-pub async fn build_queue_item_get<'a>(
-  client: &'a ClientWithMiddleware,
-  server: &'a ConfigServer,
-  url: String,
+async fn build_queue_item_get(
+  client: &ClientWithMiddleware,
+  server: &ConfigServer,
+  queue_url: &str,
 ) -> Result<JenkinsQueueItem, error::AppError> {
   let response = jenkins_request(
     client,
     server,
     reqwest::Method::GET,
-    // See https://issues.jenkins.io/browse/JENKINS-45218 which indicates
-    // the URL needs an additional "/api/<format>" suffix to work.
-    format!("{}/api/json", url),
+    format!("{}api/json?tree=executable[number,url],why", queue_url),
   )
   .await
-  .map_err(error::AppError::JenkinsEnqueue)?;
-  let buffered_response = to_buffered_response(response).await?;
-  debug!(
-    "result? {}\n{}\n{}",
-    buffered_response.status,
-    headers_to_string(buffered_response.headers)?,
-    buffered_response.text,
-  );
-  serde_json::from_str(&buffered_response.text)
+  .map_err(error::AppError::JenkinsQueueItemAwait)?;
+  let text = response
+    .text()
+    .await
+    .map_err(|e| error::AppError::JenkinsQueueItemAwait(e.into()))?;
+  serde_json::from_str(&text).map_err(error::AppError::JenkinsDeserialize)
+}
+
+// Polls a queue item until Jenkins assigns it an executable (the started build),
+// waiting the server's reported delay each round (or an assumed interval for an
+// unrecognised reason).  It has no timeout: a build can legitimately sit in the
+// queue for a long time on a busy server, so giving up on our own would be the
+// wrong surprise; a caller that wants a deadline can wrap this in one.
+async fn build_queue_item_poll(
+  client: &ClientWithMiddleware,
+  server: &ConfigServer,
+  queue_url: String,
+) -> Result<(String, u64), error::AppError> {
+  loop {
+    // await-in-loop: sequential poll — re-check the same queue item after
+    // waiting the reported (or assumed) delay; nothing runs concurrently.
+    let item = build_queue_item_get(client, server, &queue_url).await?;
+    match parse_item(&item) {
+      Right(build) => return Ok(build),
+      Left(delay) => tokio::time::sleep(delay).await,
+    }
+  }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct JenkinsJobNextBuild {
+  next_build_number: u64,
+}
+
+// Reads the number Jenkins will assign to the job's next build.  jj captures
+// this immediately before enqueuing so it can watch the resulting build: /build
+// returns the job URL, not a queue item, so there is no queue Location to
+// follow.  A concurrent trigger on the same job in the window between this read
+// and the enqueue could take the number instead, but that race is negligible
+// for a single user driving one build.
+pub async fn job_next_build_number(
+  client: &ClientWithMiddleware,
+  server: &ConfigServer,
+  job: &str,
+) -> Result<u64, error::AppError> {
+  let response = jenkins_request(
+    client,
+    server,
+    reqwest::Method::GET,
+    format!("{}/job/{}/api/json?tree=nextBuildNumber", server.host_url, job),
+  )
+  .await
+  .map_err(error::AppError::JenkinsNextBuildNumber)?;
+  let text = response
+    .text()
+    .await
+    .map_err(|e| error::AppError::JenkinsNextBuildNumber(e.into()))?;
+  serde_json::from_str::<JenkinsJobNextBuild>(&text)
+    .map(|n| n.next_build_number)
     .map_err(error::AppError::JenkinsDeserialize)
+}
+
+// Waits for the numbered build to start and returns its URL.  Jenkins may hold
+// the build in the queue (quiet period, no free executor), during which the
+// build's api/json 404s; poll until it appears.  Like the queue poll, it has no
+// timeout — a busy server may legitimately take a while to start the build.
+pub async fn build_await_start(
+  client: &ClientWithMiddleware,
+  server: &ConfigServer,
+  job: &str,
+  build_number: u64,
+) -> Result<String, error::AppError> {
+  let build_url = format!("{}/job/{}/{}/", server.host_url, job, build_number);
+  loop {
+    let response = jenkins_request(
+      client,
+      server,
+      reqwest::Method::GET,
+      format!("{}api/json?tree=number", build_url),
+    )
+    // await-in-loop: sequential poll for the build to appear; nothing to run
+    // concurrently.
+    .await
+    .map_err(error::AppError::JenkinsBuildAwait)?;
+    if response.status().is_success() {
+      return Ok(build_url);
+    }
+    if response.status() != reqwest::StatusCode::NOT_FOUND {
+      return Err(error::AppError::JenkinsBuildAwaitStatus(response.status()));
+    }
+    tokio::time::sleep(ASSUMED_QUEUE_DELAY).await;
+  }
 }
 
 pub async fn build_log_stream(
@@ -375,6 +547,9 @@ pub async fn build_log_stream(
       reqwest::Method::GET,
       format!("{}logText/progressiveText?start={}", url, start_pos),
     )
+    // await-in-loop: streaming the log in order — each page is fetched and
+    // printed, and its end offset drives the next request; sequential by
+    // construction.
     .await
     .map_err(error::AppError::JenkinsBuildStream)?;
 
@@ -408,6 +583,8 @@ async fn stream_with_prefix(
   prefix: &str,
 ) -> Result<(), error::AppError> {
   let mut stream = response.bytes_stream();
+  // await-in-loop: consuming a byte stream in arrival order; inherently
+  // sequential.
   while let Some(chunk) = stream.next().await {
     let bytes = chunk.map_err(error::AppError::JenkinsBuildResponseRead)?;
     prefixed_write(&bytes, prefix)?;
@@ -419,13 +596,13 @@ fn prefixed_write(chunk: &[u8], prefix: &str) -> Result<(), error::AppError> {
   let text = String::from_utf8_lossy(chunk);
   let stdout = std::io::stdout();
   let mut stdout_locked = stdout.lock();
-  for line in text.split('\n') {
-    if !line.is_empty() {
+  text
+    .split('\n')
+    .filter(|line| !line.is_empty())
+    .try_for_each(|line| {
       writeln!(stdout_locked, "{}{}", prefix, line)
-        .map_err(error::AppError::JenkinsBuildOutput)?;
-    }
-  }
-  Ok(())
+        .map_err(error::AppError::JenkinsBuildOutput)
+    })
 }
 
 pub async fn jenkins_job_builds(
@@ -536,4 +713,60 @@ fn headers_to_string(
     .collect::<Result<Vec<String>, reqwest::header::ToStrError>>()
     .map_err(error::AppError::JenkinsHeader)
     .map(|xs| xs.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::parse_why;
+  use std::time::Duration;
+
+  #[test]
+  fn parse_why_whole_seconds_singular_and_plural() {
+    assert_eq!(
+      parse_why("In the quiet period. Expires in 3 sec"),
+      Some(Duration::from_secs(3)),
+    );
+    assert_eq!(
+      parse_why("In the quiet period. Expires in 3 secs"),
+      Some(Duration::from_secs(3)),
+    );
+  }
+
+  #[test]
+  fn parse_why_fractional_seconds_singular_and_plural() {
+    assert_eq!(
+      parse_why("In the quiet period. Expires in 3.15 sec"),
+      Some(Duration::from_millis(3150)),
+    );
+    assert_eq!(
+      parse_why("In the quiet period. Expires in 3.15 secs"),
+      Some(Duration::from_millis(3150)),
+    );
+  }
+
+  #[test]
+  fn parse_why_milliseconds() {
+    assert_eq!(
+      parse_why("In the quiet period. Expires in 234 ms"),
+      Some(Duration::from_millis(234)),
+    );
+    // A sub-millisecond fraction is below our polling resolution.
+    assert_eq!(
+      parse_why("In the quiet period. Expires in 1.234 ms"),
+      Some(Duration::from_millis(1)),
+    );
+  }
+
+  #[test]
+  fn parse_why_treats_finished_waiting_as_a_short_wait() {
+    assert_eq!(parse_why("Finished waiting"), Some(Duration::from_secs(1)));
+  }
+
+  #[test]
+  fn parse_why_returns_none_for_an_unrecognised_reason() {
+    // e.g. waiting for an executor — the caller then polls at the assumed
+    // interval rather than giving up.
+    assert_eq!(parse_why("Waiting for next available executor"), None);
+    assert_eq!(parse_why(""), None);
+  }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -13,7 +13,6 @@ mod view;
 
 use cli::{BuildCommand, CliCommand, JobCommand};
 use config::Config;
-use futures::TryFutureExt;
 use hash_color_lib::{ColorizerOptions, HashColorizer};
 use rust_template_foundation::main as foundation_main;
 use std::process::ExitCode;
@@ -27,25 +26,17 @@ pub async fn main(config: Config) -> Result<ExitCode, error::AppError> {
       JobCommand::Run(args) => {
         let v = cli::cli_job_run_validate(&config, args)?;
         let colorizer = HashColorizer::new(ColorizerOptions::default());
-        // https://support.cloudbees.com/hc/en-us/articles/360028147532-Get-Build-Number-with-REST-API
-        // The above documentation states that the queue item should be around
-        // for 5 minutes.  We can use that to query to see which build it has
-        // produced, and then use that to poll/watch the build log.
-        jenkins::build_enqueue(&v.client, &v.server, &v.job, &v.params)
-          .and_then(|url| {
-            jenkins::build_queue_item_poll(&v.client, &v.server, url)
-          })
-          .and_then(|(build_url, build_number)| {
-            jenkins::build_log_stream(
-              &v.client,
-              &v.server,
-              build_url,
-              0,
-              build_number,
-              &colorizer,
-            )
-          })
-          .await?;
+        let (build_url, build_number) =
+          jenkins::build_start(&v.client, &v.server, &v.job, &v.params).await?;
+        jenkins::build_log_stream(
+          &v.client,
+          &v.server,
+          build_url,
+          0,
+          build_number,
+          &colorizer,
+        )
+        .await?;
         info!("Done!");
         Ok(ExitCode::SUCCESS)
       }

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -90,6 +90,73 @@ impl JenkinsTest {
   }
 }
 
+// --- job run enqueue ---
+
+// A job with no parameters block must enqueue via the plain /build endpoint;
+// buildWithParameters 400s for it, so this run formerly failed outright.
+#[test]
+#[serial]
+fn run_no_parameters_streams_to_completion() {
+  let Some(jt) = JenkinsTest::setup() else {
+    return;
+  };
+
+  jt.cmd()
+    .args(["job", "run", "no-parameters-test"])
+    .timeout(Duration::from_secs(60))
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("no-parameters-test ran"));
+}
+
+// A parameterized run must reach the job through buildWithParameters and take
+// effect: build-with-parameters-test echoes foo, so the passed value appears in
+// the streamed log rather than the default.
+#[test]
+#[serial]
+fn run_with_parameters_applies_value() {
+  let Some(jt) = JenkinsTest::setup() else {
+    return;
+  };
+
+  jt.cmd()
+    .args([
+      "job",
+      "run",
+      "build-with-parameters-test",
+      "-P",
+      "foo=integration-check",
+    ])
+    .timeout(Duration::from_secs(60))
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("foo=integration-check"));
+}
+
+// A composite multi-select (extended-choice) value is submittable only through
+// the /build json payload; buildWithParameters drops it (JENKINS-57125).
+// Passing two of the choices must echo them back through the streamed log.
+#[test]
+#[serial]
+fn run_extended_choice_applies_value() {
+  let Some(jt) = JenkinsTest::setup() else {
+    return;
+  };
+
+  jt.cmd()
+    .args([
+      "job",
+      "run",
+      "extended-choice-test",
+      "-P",
+      "colors=green,blue",
+    ])
+    .timeout(Duration::from_secs(60))
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("colors=green,blue"));
+}
+
 // --- --follow-next ---
 
 // Trigger a long-running build so --follow-next finds it already in-flight,

--- a/jenkins/generate-plugins.py
+++ b/jenkins/generate-plugins.py
@@ -20,6 +20,13 @@ import json
 WANTED = [
     "configuration-as-code",
     "workflow-aggregator",
+    # Deprecated (carries stored-XSS CVEs that only affect the Jenkins web UI,
+    # which the ephemeral localhost CI instance never exposes).  Kept solely for
+    # integration coverage: it is the one plugin that declares in a declarative
+    # Pipeline and produces a composite multi-select value, which the suite uses
+    # to exercise jj's /build json enqueue path (buildWithParameters drops such
+    # values — JENKINS-57125).  See jenkins/jobs/extended-choice-test.groovy.
+    "extended-choice-parameter",
 ]
 
 UPDATE_CENTER = "https://updates.jenkins.io/stable/update-center.actual.json"

--- a/jenkins/jobs/extended-choice-test.groovy
+++ b/jenkins/jobs/extended-choice-test.groovy
@@ -1,0 +1,27 @@
+// Exercises a composite multi-select parameter through jj's /build json enqueue
+// path.  buildWithParameters drops an extended-choice value (JENKINS-57125),
+// while the json payload jj posts to /build carries it.  The
+// extended-choice-parameter plugin is deprecated and kept solely for this
+// coverage; production jobs should prefer a maintained parameter type.
+pipeline {
+  agent any
+  parameters {
+    extendedChoice(
+      name: 'colors',
+      type: 'PT_CHECKBOX',
+      value: 'red,green,blue',
+      multiSelectDelimiter: ',',
+      quoteValue: false,
+      saveJSONParameterToFile: false,
+      visibleItemCount: 3,
+      description: 'A composite multi-select parameter.'
+    )
+  }
+  stages {
+    stage('Echo') {
+      steps {
+        echo "colors=${params.colors}"
+      }
+    }
+  }
+}

--- a/jenkins/jobs/no-parameters-test.groovy
+++ b/jenkins/jobs/no-parameters-test.groovy
@@ -1,0 +1,13 @@
+// A job with no parameters block at all, exercising the plain /build enqueue
+// path jj must use when a run supplies no parameters.  buildWithParameters
+// 400s for such a job, so this is the case that formerly could not run.
+pipeline {
+  agent any
+  stages {
+    stage('Echo') {
+      steps {
+        echo 'no-parameters-test ran'
+      }
+    }
+  }
+}

--- a/jenkins/plugins.nix
+++ b/jenkins/plugins.nix
@@ -1,5 +1,5 @@
-# Jenkins plugin definitions — configuration-as-code, workflow-aggregator
-# and all of their required transitive dependencies.
+# Jenkins plugin definitions — configuration-as-code, workflow-aggregator,
+# extended-choice-parameter and all of their required transitive dependencies.
 #
 # To regenerate this file (e.g. after adding a plugin or updating versions):
 #
@@ -522,6 +522,15 @@
     src = fetchurl {
       url = "https://updates.jenkins.io/download/plugins/workflow-aggregator/608.v67378e9d3db_1/workflow-aggregator.hpi";
       hash = "sha256-e5QifBr6AbsmLBSRmtSjM0EvG1HZR8DyGQnsLa/zV9w=";
+    };
+    phases = ["installPhase"];
+    installPhase = "cp $src $out";
+  };
+  "extended-choice-parameter" = stdenv.mkDerivation {
+    name = "extended-choice-parameter";
+    src = fetchurl {
+      url = "https://updates.jenkins.io/download/plugins/extended-choice-parameter/388.ve7b_d0b_920e10/extended-choice-parameter.hpi";
+      hash = "sha256-KaAsq+uQwcbXlztg28ZBzysQoxmgVyWRZcioLIZP5Cg=";
     };
     phases = ["installPhase"];
     installPhase = "cp $src $out";

--- a/tasks.org
+++ b/tasks.org
@@ -4,3 +4,115 @@
 The project's backlog.  Record plans and work items here as ~* TODO~ entries —
 see the "Capturing plans" guidance in =llms.org= — cross-linking related entries
 and marking finished work ~* DONE~.
+
+* DONE Enqueue jobs regardless of whether they declare build parameters
+
+~build_enqueue~ always POSTed to a job's ~/buildWithParameters~ endpoint, which
+Jenkins rejects with =400 Bad Request= for a job that declares no parameters —
+so jj could not run a non-parameterized job at all — and which silently drops
+the values of richer parameter types such as an =ExtendedChoiceParameter=
+(JENKINS-57125, still present in the current plugin and confirmed live).
+
+Resolved: jj now chooses the enqueue endpoint per run.  A parameterless job goes
+to ~/build~ and a parameterized one to ~/buildWithParameters~ — the documented
+API, which returns a queue-item =Location= jj polls to get the exact started
+build (race-free).  A run falls back to the web UI's ~/build~ ~json~ form only
+when it sets a parameter whose type is not on jj's known-good list; the form
+carries every value but returns the job URL rather than a queue item
+(JENKINS-30317, resolved "Not A Defect"), so there jj records the job's
+~nextBuildNumber~ before enqueuing and watches that build.  That leaves a small
+enqueue race, but only for those runs and only under concurrent triggering of
+the same job.
+
+The routing keys on each parameter definition's ~_class~ against a built-in list
+of core Jenkins parameter types buildWithParameters is known to carry, plus a
+per-server ~build_with_parameters_additional_types~ config list.  It is a
+/known-good/ list by design: an unrecognized plugin type degrades to the form
+(the visible race) rather than to a silently dropped value (JENKINS-57125, the
+failure mode of a known-bad list), and jj is not on the hook to hardcode every
+plugin's parameter type.  The quiet-period regex the old queue poll used is gone
+— the poll now just waits for the queue item to be assigned an executable.
+
+Integration coverage (=crates/cli/tests/integration_test.rs=), all validated
+against a live Jenkins:
+- A non-parameterized run (new =no-parameters-test= job).
+- A parameterized run asserting the passed value takes effect
+  (=build-with-parameters-test=).
+- A composite multi-select run asserting the value survives (new
+  =extended-choice-test= job) — the case ~/buildWithParameters~ would drop.
+
+Plugin note: the composite test uses =extended-choice-parameter=, which is
+deprecated with stored-XSS CVEs.  No maintained equivalent fits this harness —
+=extensible-choice-parameter= has no Pipeline support and Active Choices is
+UI-oriented and does not reproduce the headless value-drop.  The CVEs need a
+Jenkins web-UI victim, which the ephemeral localhost CI instance never exposes,
+so it is pinned for test coverage only; real jobs should migrate to a maintained
+parameter type.  All three jobs are hydrated by =.github/scripts/run-tests.sh=
+before the suite runs.
+
+* TODO Warn when a parameterized job's first build drops its values
+
+A Pipeline job declares its parameters inside the ~parameters {}~ block, which
+Jenkins only registers as the job's parameter /definitions/ after the job has
+built once.  Until then, values passed to a build are silently dropped.  Now
+that jj enqueues through ~/build~ this no longer surfaces as a 400 — the build
+just runs with the passed values ignored, which is arguably worse because it
+looks like it worked.  The integration runner hydrates every job with one
+throwaway build to sidestep this, but a real jj user hits the same first-build
+behaviour with no hint as to the cause.  Consider detecting a job whose
+parameter definitions are not yet registered and warning before the run.
+
+The integration harness these build on lives in
+=.github/workflows/integration.yml=, =.github/scripts/run-tests.sh=, =jenkins/=
+(job Groovy, JCasC, plugin pins), and the =jenkins= override in =flake.nix=.
+
+* TODO Split jenkins.rs into a jenkins/ module directory
+
+=crates/cli/src/jenkins.rs= has grown large and spaghetti-like: it mixes
+enqueuing, queue/build polling, log streaming, and general REST queries in one
+file.  Break it into a =jenkins/= directory of focused modules, each covering
+one area of functionality:
+
+- An /enqueue/ module: "I want to start a job" — given a job and parameters, it
+  picks the endpoint, submits, and hands back the started build.
+- A /log/ (console) module: polling for and printing a build's log to
+  completion.
+- A /rest/ module: the plain queries — listing a job's builds, build detail,
+  fetching a console log, and similar read-only calls.
+
+Shared plumbing (the authenticated request helper, the buffered-response type,
+header parsing) can live in the module root or a small shared module.  Move code
+without changing behaviour; the integration suite should pass unchanged.
+
+* TODO Nail down config precedence: env -> config (global -> server) -> cli
+
+jj should resolve every layered setting along one axis, with the right-most
+winning: an env var is the base, the config file overrides it (and within the
+file a per-server value overrides a global one), and a CLI flag overrides all of
+it — so =cli > server > global > env=.  The env -> config -> cli half is handled
+by the foundation's =MergeConfig=; the global -> server half (jj's own server
+registry) is not wired yet, so today only per-server values exist.
+
+Capture this axis as the /spec/ in a design doc (e.g. =docs/config.org=), and
+state that any resolution order other than the above is a bug.  Then make the
+registry actually enforce global -> server so the doc is true.  The two entries
+below build on this.
+
+* TODO Make build_with_parameters_additional_types global as well as per-server
+
+Today the list of extra buildWithParameters-safe parameter classes lives only on
+each server.  Add a global (top-level) list too, and take the /union/ of the
+global and per-server lists as the effective set — it is an additive allowlist,
+so a server adds to the global list rather than replacing it (the one place
+"server wins" reads as "server extends").  Depends on the precedence entry
+above.
+
+* TODO Add an opt-in timeout for waiting on a queued or starting build
+
+The queue poll and the build-start poll both wait indefinitely by design — a
+build can legitimately sit in the queue for a long time on a busy server, and
+giving up on our own would be a nasty release-night surprise.  Add an /optional/
+timeout, unset by default, that makes those polls give up when it elapses.
+Expose it as a global config value, a per-server override, and a CLI flag,
+resolved by the precedence entry above (=cli > server > global=).  Ctrl+C stays
+the manual escape when no timeout is set.


### PR DESCRIPTION
jj posted every job run to Jenkins' buildWithParameters endpoint, which rejects a job that declares no parameters with 400 — so a parameterless job could not run at all — and silently drops the values of richer parameter types such as an extended-choice parameter.

No single Jenkins endpoint both carries every parameter type and returns a queue-item handle, so jj now chooses per run. A parameterless job goes to the build endpoint and a parameterized one to buildWithParameters — the documented API, which returns a queue item jj watches to follow the exact build with no race. A run falls back to the web UI's build form — which carries every value but returns the job page rather than a queue item — only when it sets a parameter whose type is not known to survive buildWithParameters; there jj records the number the next build will take and watches that build. The choice is made from a known-good list of core parameter types plus a per-server config list, so an unrecognised type degrades to the visible race rather than to a silently dropped value.

While a build sits in the queue, jj waits the delay the queue item reports — Jenkins' own quiet-period countdown, read across its second and millisecond forms — before re-checking, and polls indefinitely: a build can legitimately wait a long time on a busy server, so giving up unprompted would be the wrong surprise.

Integration coverage runs a parameterless job, a parameterized job whose value must take effect, and a composite multi-select job whose value must survive, all against a live Jenkins. The multi-select case pins a deprecated choice plugin — no maintained one both declares in a declarative Pipeline and reproduces the value drop headlessly — used for test coverage only on the ephemeral CI instance, which never exposes the plugin's web-UI CVEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
